### PR TITLE
fix(next): correct client/server boundaries and routing

### DIFF
--- a/app/app/admin/dashboard/page.tsx
+++ b/app/app/admin/dashboard/page.tsx
@@ -1,5 +1,4 @@
-
-'use client'
+"use client";
 
 import { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button'

--- a/app/app/auth/login/page.tsx
+++ b/app/app/auth/login/page.tsx
@@ -1,5 +1,4 @@
-
-'use client'
+"use client";
 
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'

--- a/app/app/auth/signup/page.tsx
+++ b/app/app/auth/signup/page.tsx
@@ -1,5 +1,4 @@
-
-'use client'
+"use client";
 
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'

--- a/app/app/company/dashboard/page.tsx
+++ b/app/app/company/dashboard/page.tsx
@@ -1,5 +1,4 @@
-
-'use client'
+"use client";
 
 import { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button'

--- a/app/app/consultant/dashboard/page.tsx
+++ b/app/app/consultant/dashboard/page.tsx
@@ -1,5 +1,4 @@
-
-'use client'
+"use client";
 
 import { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button'

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -1,12 +1,8 @@
-
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import './globals.css'
 import { ThemeProvider } from '@/components/theme-provider'
 import { Toaster } from '@/components/ui/toaster'
 import { AuthProvider } from '@/lib/auth-context'
-
-const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
   title: 'ISO Connect - Professional ISO Consultant Marketplace',
@@ -20,7 +16,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className} suppressHydrationWarning>
+      <body suppressHydrationWarning>
         <ThemeProvider
           attribute="class"
           defaultTheme="light"

--- a/app/components/consultant-profile.tsx
+++ b/app/components/consultant-profile.tsx
@@ -1,5 +1,4 @@
-
-'use client'
+"use client";
 
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'

--- a/app/components/consultants-directory.tsx
+++ b/app/components/consultants-directory.tsx
@@ -1,5 +1,4 @@
-
-'use client'
+"use client";
 
 import { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button'

--- a/app/components/ui/task-card.tsx
+++ b/app/components/ui/task-card.tsx
@@ -1,10 +1,16 @@
-import { useState } from 'react'
+"use client";
+
+import dynamic from 'next/dynamic'
 import { Card, CardContent, CardHeader, CardTitle } from './card'
 import { Badge } from './badge'
 import { Checkbox } from './checkbox'
 import { Button } from './button'
 import { Pencil, Trash2 } from 'lucide-react'
-import { motion } from 'framer-motion'
+
+const MotionDiv = dynamic(
+  () => import('framer-motion').then((mod) => mod.motion.div),
+  { ssr: false }
+)
 
 interface TaskCardProps {
   id: string
@@ -28,7 +34,7 @@ export function TaskCard({
   onEdit,
 }: TaskCardProps) {
   return (
-    <motion.div
+    <MotionDiv
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -20 }}
@@ -61,6 +67,6 @@ export function TaskCard({
           </Badge>
         </CardContent>
       </Card>
-    </motion.div>
+    </MotionDiv>
   )
 }

--- a/app/lib/auth-context.tsx
+++ b/app/lib/auth-context.tsx
@@ -1,5 +1,4 @@
-
-'use client'
+"use client";
 
 import { createContext, useContext, useEffect, useState } from 'react'
 import { createSupabaseClient } from '@/lib/supabase'


### PR DESCRIPTION
## Summary
- ensure client-only pages and components declare `use client`
- dynamically import heavy framer-motion usage
- remove remote font dependency for stable builds

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68a66309dcec8330b5d5f8a06d2255f4